### PR TITLE
Dark mode added, and comments overlapping pixels adjusted.

### DIFF
--- a/partyfinder.lua
+++ b/partyfinder.lua
@@ -697,7 +697,7 @@ local function RenderInterface()
     end
 	
 	-- Pop the styles to restore the imgui styles stack
-	PopStyles(darkPfStyles); 
+	PopStyles(stylesToUse); 
 	
 end
 


### PR DESCRIPTION
- The comment icons were overlapping creating a weird looking skew.

![image](https://github.com/CatsAndBoats/PartyFinder/assets/10678415/502eef22-e429-4fe2-9517-f781495d10df)

Corrected
![image](https://github.com/CatsAndBoats/PartyFinder/assets/10678415/20ec51e1-3124-410f-a8f8-9166ae020464)

- Added dark mode imgStyleset and checkbox to switch.

![image](https://github.com/CatsAndBoats/PartyFinder/assets/10678415/eebb74fa-5235-4a03-bc8d-e6e55476c9d7)

and

![image](https://github.com/CatsAndBoats/PartyFinder/assets/10678415/01999fef-fee7-44fc-830f-0ddabde182b6)