### PR TITLE
Feature/saving pf settings

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -1,0 +1,7 @@
+-- Tinker in game, LUA caches the results
+return {
+  levelFilterCheckbox = false, -- or false
+  levelRange = 10, -- or some other value(Numeric)
+  commentBoxEnabled = false, -- or false
+  darkModeEnabled = false -- or false
+}

--- a/config.lua
+++ b/config.lua
@@ -1,6 +1,0 @@
-return {
-    darkModeEnabled = false,
-    commentBoxEnabled = false,
-    levelFilterCheckbox = true,
-    levelRange = 30,
-}

--- a/config.lua
+++ b/config.lua
@@ -1,7 +1,6 @@
--- Tinker in game, LUA caches the results
 return {
-  levelFilterCheckbox = false, -- or false
-  levelRange = 10, -- or some other value(Numeric)
-  commentBoxEnabled = false, -- or false
-  darkModeEnabled = false -- or false
+    darkModeEnabled = false,
+    commentBoxEnabled = false,
+    levelFilterCheckbox = true,
+    levelRange = 30,
 }

--- a/partyfinder.lua
+++ b/partyfinder.lua
@@ -240,6 +240,8 @@ levelRangeInput[1] = settings.levelRange
 
 -- Save Configuration based on player involvement
 -- Function to save configuration settings to a file
+
+
 local function saveConfig()
     local configFile, err = io.open("config.lua", "w")
     if not configFile then
@@ -247,11 +249,11 @@ local function saveConfig()
         return
     end
     -- Print current configuration settings(Debug)
-    print("Saving configuration with the following settings:")
-    print("    Dark Mode Enabled: " .. tostring(darkModeEnabled[1]))
-    print("    Comment Box Enabled: " .. tostring(commentSetColumnEnabled[1]))
-    print("    Level Filter Checkbox: " .. tostring(levelFilterCheckbox[1]))
-    print("    Level Range: " .. tostring(levelRangeInput[1]))
+    -- print("Saving configuration with the following settings:")
+    -- print("    Dark Mode Enabled: " .. tostring(darkModeEnabled[1]))
+    -- print("    Comment Box Enabled: " .. tostring(commentSetColumnEnabled[1]))
+    -- print("    Level Filter Checkbox: " .. tostring(levelFilterCheckbox[1]))
+    -- print("    Level Range: " .. tostring(levelRangeInput[1]))
 
     -- Writing the configuration settings to the file
     configFile:write("return {\n")

--- a/partyfinder.lua
+++ b/partyfinder.lua
@@ -233,7 +233,7 @@ local darkPfStyles = {
 local function save_settings()
     -- Directly save the 'cfg' table
     settings.save('cfg');
-    print("Save Complete...")
+    --print("Save Complete...")
 end
 
 


### PR DESCRIPTION
Added config settings, to save players preferences.

![image](https://github.com/CatsAndBoats/PartyFinder/assets/10678415/0b5652c9-2fca-4f97-97ce-796abc5d64bb)

This includes Loading from previous settings and saving after the player changes a value, working for DarkMode, Filter Range, Filter Checkbox and Comments checkbox.